### PR TITLE
Add Similar Posts Feature

### DIFF
--- a/blog/templates/blog/post/detail.html
+++ b/blog/templates/blog/post/detail.html
@@ -11,7 +11,14 @@
     Share this post
     </a>
  </p>
-
+ <h2>Similar posts</h2>
+ {% for post in similar_posts %}
+  <p>
+  <a href="{{ post.get_absolute_url }}">{{ post.title }}</a>
+  </p>
+ {% empty %}
+  There are no similar posts yet.
+ {% endfor %}
  {% with comments.count as total_comments %}
  <h2>
  {{ total_comments }} comment{{ total_comments|pluralize }}


### PR DESCRIPTION
**Changes made**
- Implemented a feature to display similar posts on the blog.
- Introduced a `queryset` to filter similar posts based on shared tags.
- Used the annotate function to count shared tags and ordered results by the number of shared tags and publication date.
- Limited the results to the top four similar posts.
- Integrated the feature into the blog template `detail.html`.