### PR TITLE
Add Sitemap Configuration

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -51,6 +51,7 @@ class Post(models.Model):
     def __str__(self):
         # Return a human-readable string representation of the post
         return self.title
+    
     def get_absolute_url(self):
         return reverse('blog:post_detail',
                        args=[

--- a/blog/sitemaps.py
+++ b/blog/sitemaps.py
@@ -1,0 +1,12 @@
+from django.contrib.sitemaps import Sitemap
+from .models import Post 
+
+class PostSitemap(Sitemap):
+    changefreq = 'weekly'
+    priority = 0.9 
+
+    def items(self):
+        return Post.published.all()
+    
+    def lastmod(self,obj):
+        return obj.updated

--- a/blog/templates/blog/post/list.html
+++ b/blog/templates/blog/post/list.html
@@ -25,7 +25,7 @@
  <p class="date">
  Published {{ post.publish }} by {{ post.author }}
  </p>
- {{ post.body| markdown |truncatewords_html:30 }}
+ {{ post.body| markdown | truncatewords_html:30 }}
  {% endfor %}
  {% include "pagination.html" with page=posts %}
 {% endblock %}

--- a/blogsite/settings.py
+++ b/blogsite/settings.py
@@ -39,6 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'blog.apps.BlogConfig',
     'taggit',
+    'django.contrib.sites',
+    'django.contrib.sitemaps',
 ]
 
 MIDDLEWARE = [
@@ -132,3 +134,5 @@ EMAIL_PORT = '587'
 EMAIL_HOST = env('EMAIL_HOST')
 EMAIL_HOST_USER = env('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
+
+SITE_ID = 1

--- a/blogsite/urls.py
+++ b/blogsite/urls.py
@@ -17,7 +17,15 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.urls import path, include
+from django.contrib.sitemaps.views import sitemap 
+from blog.sitemaps import PostSitemap
+
+sitemaps = {
+ 'posts': PostSitemap,
+}
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('blog/', include('blog.urls', namespace='blog')),
+    path('sitemap.xml', sitemap, {'sitemaps':sitemaps}, name='django.contrib.sitemaps.views.sitemap')
 ]


### PR DESCRIPTION
**Changes made**

- Configured the sitemap for the Django project.
- Implemented the `PostSitemap` class in the `blog.sitemaps` module.
- Added the sitemap path in the project's `urlpatterns` to enable sitemap functionality.
- Assigned `SITE_ID` to 1 in `settings.py`